### PR TITLE
Add flag for checking signature from dana

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,14 +12,15 @@ import (
 
 // Client struct
 type Client struct {
-	BaseUrl      string
-	Version      string
-	ClientId     string
-	ClientSecret string
-	PrivateKey   []byte
-	PublicKey    []byte
-	LogLevel     int
-	Logger       *log.Logger
+	BaseUrl         string
+	Version         string
+	ClientId        string
+	ClientSecret    string
+	PrivateKey      []byte
+	PublicKey       []byte
+	VerifySignature bool
+	LogLevel        int
+	Logger          *log.Logger
 }
 
 // NewClient : this function will always be called when the library is in use
@@ -30,8 +31,9 @@ func NewClient() Client {
 		// 1: Errors only
 		// 2: Errors + informational (default)
 		// 3: Errors + informational + debug
-		LogLevel: 2,
-		Logger:   log.New(os.Stderr, "", log.LstdFlags),
+		VerifySignature: true,
+		LogLevel:        2,
+		Logger:          log.New(os.Stderr, "", log.LstdFlags),
 	}
 }
 

--- a/core.go
+++ b/core.go
@@ -58,10 +58,12 @@ func (gateway *CoreGateway) Order(reqBody *OrderRequestData) (res ResponseBody, 
 
 	res.Response.Body = orderResponseData
 
-	//response RSA verification
-	err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
-	if err != nil {
-		err = fmt.Errorf("could not verify request: %v", err)
+	if gateway.Client.VerifySignature {
+		//response RSA verification
+		err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
+		if err != nil {
+			err = fmt.Errorf("could not verify request: %v", err)
+		}
 	}
 
 	return
@@ -81,9 +83,11 @@ func (gateway *CoreGateway) OrderDetail(reqBody *OrderDetailRequestData) (res Re
 
 	res.Response.Body = orderDetailData
 
-	err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
-	if err != nil {
-		err = fmt.Errorf("could not verify request: %v", err)
+	if gateway.Client.VerifySignature {
+		err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
+		if err != nil {
+			err = fmt.Errorf("could not verify request: %v", err)
+		}
 	}
 
 	return
@@ -105,9 +109,11 @@ func (gateway *CoreGateway) Refund(reqBody *RefundRequestData) (res ResponseBody
 
 	res.Response.Body = RefundResponseData
 
-	err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
-	if err != nil {
-		err = fmt.Errorf("could not verify request: %v", err)
+	if gateway.Client.VerifySignature {
+		err = verifySignature(res.Response, res.Signature, gateway.Client.PublicKey)
+		if err != nil {
+			err = fmt.Errorf("could not verify request: %v", err)
+		}
 	}
 
 	return


### PR DESCRIPTION
Add `client.VerifySignature = false` to skip checking signature on dana response.
