### PR TITLE
Fix bug in refund verify signature

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -46,8 +46,8 @@ type OrderDetailData struct {
 
 type RefundResponseData struct {
 	ResultInfo ResultInfo `json:"resultInfo" valid:"required"`
-	RefundID   *string    `json:"refundId,omitempty" valid:"optional"`
 	RequestID  *string    `json:"requestId,omitempty" valid:"optional"`
+	RefundID   *string    `json:"refundId,omitempty" valid:"optional"`
 }
 
 type ResultInfo struct {


### PR DESCRIPTION
Bug found in verify signature on refund caused by different json element order. Fix json element order to match the response from dana.